### PR TITLE
Make South dependency optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,4 @@ setup(
         'Framework :: Django',
     ],
     test_suite='runtests.runtests',
-    dependency_links=[
-        'http://pypi.python.org/pypi/South/',
-    ],
-    install_requires=[
-        'South',
-    ],
 )

--- a/updown/fields.py
+++ b/updown/fields.py
@@ -243,13 +243,17 @@ class AnonymousRatingField(RatingField):
         super(AnonymousRatingField, self).__init__(*args, **kwargs)
 
 
-from south.modelsinspector import add_introspection_rules
-add_introspection_rules([
-    (
-        [RatingField],  # Class(es) these apply to
-        [],             # Positional arguments (not used)
-        {               # Keyword argument
-            "delimiter": ["delimiter", {"default": "|"}],
-        },
-    ),
-], ["^updown\.fields\.RatingField"])
+try:
+    from south.modelsinspector import add_introspection_rules
+except ImportError:
+    pass
+else:
+    add_introspection_rules([
+        (
+            [RatingField],  # Class(es) these apply to
+            [],             # Positional arguments (not used)
+            {               # Keyword argument
+                "delimiter": ["delimiter", {"default": "|"}],
+            },
+        ),
+    ], ["^updown\.fields\.RatingField"])


### PR DESCRIPTION
Hi there

The South dependency that was introduced in #6 bugs me a little. We don't use South where I work, and if possible I'd like to drop the dependency.

If I got this correctly, the only place where it is imported/needed is in fields.py, where a rule is added in order to add support to South for the specific field type. Right?

In that case, if the import fails, the code could be skipped.

Code is attached.
