### PR TITLE
Supported for django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,30 @@
 language: python
+cache: pip
 
 python:
-  - "3.5"
+    - "2.7"
+    - "3.4"
+    - "3.5"
 
 sudo: false
 
 env:
-    - TOX_ENV=py35-django110
-    - TOX_ENV=py34-django110
-    - TOX_ENV=py27-django110
-    - TOX_ENV=py36-django111
-    - TOX_ENV=py35-django111
-    - TOX_ENV=py34-django111
-    - TOX_ENV=py27-django111
-    - TOX_ENV=py36-django20
-    - TOX_ENV=py35-django20
-    - TOX_ENV=py34-django20
+    - DJANGO=1.10
+    - DJANGO=1.11
+    - DJANGO=2.0
 
 matrix:
-  fast_finish: true
+    fast_finish: true
+
+    include:
+      - { python: "3.6", env: DJANGO=1.11 }
+      - { python: "3.6", env: DJANGO=2.0 }
+
+    exclude:
+      - { python: "2.7", env: DJANGO=2.0 }
 
 install:
-  # Virtualenv < 14 is required to keep the Python 3.2 builds running.
-  - pip install tox "virtualenv<14"
+    - pip install tox tox-travis
 
 script:
-    - tox -e $TOX_ENV
+    - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,13 @@ env:
     - TOX_ENV=py35-django110
     - TOX_ENV=py34-django110
     - TOX_ENV=py27-django110
-    - TOX_ENV=py35-django19
-    - TOX_ENV=py34-django19
-    - TOX_ENV=py27-django19
-    - TOX_ENV=py34-django18
-    - TOX_ENV=py33-django18
-    - TOX_ENV=py27-django18
+    - TOX_ENV=py36-django111
+    - TOX_ENV=py35-django111
+    - TOX_ENV=py34-django111
+    - TOX_ENV=py27-django111
+    - TOX_ENV=py36-django20
+    - TOX_ENV=py35-django20
+    - TOX_ENV=py34-django20
 
 matrix:
   fast_finish: true

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
        {py27,py33,py34}-django18
        {py27,py34,py35}-django19
        {py27,py34,py35}-django110
+       {py27,py34,py35}-django20
 
 
 [testenv]
@@ -14,8 +15,8 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
        PYTHONWARNINGS=once
 deps =
-        django18: Django==1.8
         django19: Django==1.9
         django110: Django==1.10
+        django20: Django==2.0
         pytest
         pytest-django

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ addopts=--tb=short
 
 [tox]
 envlist =
-       {py27,py33,py34}-django18
        {py27,py34,py35}-django19
        {py27,py34,py35}-django110
        {py27,py34,py35}-django20

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,15 @@ envlist =
        {py27,py34,py35,py36}-django111,
        {py34,py35,py36}-django20,
 
+[travis:env]
+DJANGO =
+    1.10: django110
+    1.11: django111
+    2.0: django20
+
 [testenv]
 commands = py.test tests/
+envdir = {toxworkdir}/venvs/{envname}
 setenv =
        PYTHONDONTWRITEBYTECODE=1
        PYTHONWARNINGS=once

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,9 @@ addopts=--tb=short
 
 [tox]
 envlist =
-       {py27,py34,py35}-django19
-       {py27,py34,py35}-django110
-       {py27,py34,py35}-django20
-
+       {py27,py34,py35}-django110,
+       {py27,py34,py35,py36}-django111,
+       {py34,py35,py36}-django20,
 
 [testenv]
 commands = py.test tests/
@@ -14,8 +13,8 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
        PYTHONWARNINGS=once
 deps =
-        django19: Django==1.9
-        django110: Django==1.10
-        django20: Django==2.0
+        django110: Django>=1.10,<1.11
+        django111: Django>=1.11,<2.0
+        django20: Django>=2.0,<2.1
         pytest
         pytest-django

--- a/updown/fields.py
+++ b/updown/fields.py
@@ -44,6 +44,12 @@ class RatingManager(object):
         self.like_field_name = "{}_likes".format(self.field.name,)
         self.dislike_field_name = "{}_dislikes".format(self.field.name,)
 
+    def is_authenticated(self, user):
+        """ different method between django 1.* and 2.* """
+        if callable(user.is_authenticated):
+            return user.is_authenticated()
+        return user.is_authenticated
+
     def get_rating_for_user(self, user, ip_address=None):
         kwargs = {
             'content_type': self.get_content_type(),
@@ -51,7 +57,7 @@ class RatingManager(object):
             'key': self.field.key
         }
 
-        if not (user and user.is_authenticated()):
+        if not (user and self.is_authenticated(user)):
             if not ip_address:
                 raise ValueError("``user`` or ``ip_address`` must be "
                                  "present.")
@@ -83,7 +89,7 @@ class RatingManager(object):
         if score not in SCORE_TYPES.values():
             raise InvalidRating("{} is not a valid score".format(score))
 
-        is_anonymous = (user is None or not user.is_authenticated())
+        is_anonymous = (user is None or not self.is_authenticated(user))
         if is_anonymous and not self.field.allow_anonymous:
             raise AuthRequired("User must be a user, not '{}'".format(user))
 

--- a/updown/migrations/0001_initial.py
+++ b/updown/migrations/0001_initial.py
@@ -24,8 +24,8 @@ class Migration(migrations.Migration):
                 ('ip_address', models.GenericIPAddressField()),
                 ('date_added', models.DateTimeField(default=django.utils.timezone.now, editable=False)),
                 ('date_changed', models.DateTimeField(default=django.utils.timezone.now, editable=False)),
-                ('content_type', models.ForeignKey(related_name='updown_votes', to='contenttypes.ContentType')),
-                ('user', models.ForeignKey(related_name='updown_votes', blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+                ('content_type', models.ForeignKey(related_name='updown_votes', to='contenttypes.ContentType', on_delete=models.CASCADE)),
+                ('user', models.ForeignKey(related_name='updown_votes', blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE)),
             ],
             options={
             },

--- a/updown/models.py
+++ b/updown/models.py
@@ -18,12 +18,13 @@ SCORE_TYPES = dict((value, key) for key, value in _SCORE_TYPE_CHOICES)
 
 
 class Vote(models.Model):
-    content_type = models.ForeignKey(ContentType, related_name="updown_votes")
+    content_type = models.ForeignKey(ContentType, related_name="updown_votes", 
+                                     on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     key = models.CharField(max_length=32)
     score = models.SmallIntegerField(choices=_SCORE_TYPE_CHOICES)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True,
-                             related_name="updown_votes")
+                             related_name="updown_votes", on_delete=models.CASCADE)
     ip_address = models.GenericIPAddressField()
     date_added = models.DateTimeField(default=timezone.now, editable=False)
     date_changed = models.DateTimeField(default=timezone.now, editable=False)

--- a/updown/models.py
+++ b/updown/models.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
+from django.utils.encoding import python_2_unicode_compatible
 from django.conf import settings
 from django.utils import timezone
 
@@ -17,6 +18,7 @@ _SCORE_TYPE_CHOICES = (
 SCORE_TYPES = dict((value, key) for key, value in _SCORE_TYPE_CHOICES)
 
 
+@python_2_unicode_compatible
 class Vote(models.Model):
     content_type = models.ForeignKey(ContentType, related_name="updown_votes", 
                                      on_delete=models.CASCADE)
@@ -35,7 +37,7 @@ class Vote(models.Model):
         unique_together = (('content_type', 'object_id', 'key', 'user',
                             'ip_address'))
 
-    def __unicode__(self):
+    def __str__(self):
         return u"%s voted %s on %s" % (self.user, self.score,
                                        self.content_object)
 


### PR DESCRIPTION
- fixed `on_delete=models.CASCADE` that required for Django>=2.0
- fixed: 'bool' object is not callable is_authenticated